### PR TITLE
chore: Bump the version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 app/*
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tfdoc"
 edition = "2021"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Even Solberg <even.solberg@gmail.com>, Thomas Maurin <maur1th@users.noreply.github.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/evensolberg/tfdoc"
@@ -21,3 +21,5 @@ inherits = "release"
 debug = true
 split-debuginfo = "packed"
 
+[profile.release]
+strip = true


### PR DESCRIPTION
- Bump the version after the CLAP update
- Add Cargo.lock to .gitignore